### PR TITLE
fix: Properly color empty activities with ligth grey on the circular heatmap component

### DIFF
--- a/src/app/component/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.ts
@@ -712,7 +712,7 @@ export class CircularHeatmapComponent implements OnInit {
       if (cntAll !== 0) {
         this.ALL_CARD_DATA[index]['Done%'] = cntTrue / cntAll;
       } else {
-        this.ALL_CARD_DATA[index]['Done%'] = 0;
+        this.ALL_CARD_DATA[index]['Done%'] = -1;
       }
       var color = d3
         .scaleLinear<string, string>()
@@ -728,7 +728,7 @@ export class CircularHeatmapComponent implements OnInit {
         return color(_self.ALL_CARD_DATA[index]['Done%']);
       });
     }
-    // this.noActivitytoGrey();
+    this.noActivitytoGrey();
   }
 
   ResetIsImplemented() {


### PR DESCRIPTION
fix #264 