### PR TITLE
Add Level of an Activity to Excel

### DIFF
--- a/src/app/component/mapping/mapping.component.html
+++ b/src/app/component/mapping/mapping.component.html
@@ -178,9 +178,7 @@
     <tr *ngFor="let item of allMappingDataSortedByISO17">
       <!-- checking if item is defined and set & truncating at 32767 characters per cell to fit to excel limitations-->
       <td>
-        <ng-container *ngIf="item.level && item.level.length > 0">
-          {{ item.level | slice : 0 : 32767 }}</ng-container
-        >
+        {{ item.level }}
       </td>
       <td>
         <ng-container *ngIf="item.dimension && item.dimension.length > 0">

--- a/src/app/component/mapping/mapping.component.html
+++ b/src/app/component/mapping/mapping.component.html
@@ -152,6 +152,7 @@
 
   <table id="excel-table" class="hide">
     <tr>
+      <th>Level</th>
       <th>Dimension</th>
       <th>Sub Dimension</th>
       <th>Activity</th>
@@ -176,6 +177,11 @@
     </tr>
     <tr *ngFor="let item of allMappingDataSortedByISO17">
       <!-- checking if item is defined and set & truncating at 32767 characters per cell to fit to excel limitations-->
+      <td>
+        <ng-container *ngIf="item.level && item.level.length > 0">
+          {{ item.level | slice : 0 : 32767 }}</ng-container
+        >
+      </td>
       <td>
         <ng-container *ngIf="item.dimension && item.dimension.length > 0">
           {{ item.dimension | slice : 0 : 32767 }}</ng-container

--- a/src/app/component/mapping/mapping.component.ts
+++ b/src/app/component/mapping/mapping.component.ts
@@ -49,6 +49,7 @@ export interface MappingElementSortedByISO17 {
   teamImplementation: {
     [key: string]: boolean;
   };
+  level: string;
 }
 
 export interface MappingElementSortedByISO22 {
@@ -343,6 +344,8 @@ export class MappingComponent implements OnInit {
     var CurrentTeamsAndImplementation =
       this.YamlObject[dim][subDim][activity]['teamsImplemented'];
 
+    var CurrentLevel = this.YamlObject[dim][subDim][activity]['level'];
+
     this.temporaryMappingElement = {
       dimension: dim,
       subDimension: subDim,
@@ -363,6 +366,7 @@ export class MappingComponent implements OnInit {
       comments: CurrentComments,
       assessment: CurrentAssessment,
       teamImplementation: CurrentTeamsAndImplementation,
+      level: CurrentLevel,
     };
 
     console.log(this.temporaryMappingElement);


### PR DESCRIPTION
Since we want to use the Excel file as a reference to map against a companies ISO requirements, we need also the level attribute. Because we want to conenctrate on lower level.

This adds the levle property from the parsed YAML object to the temp object and to the allMappingDataSortedByISO17 which seem to be the source for the hiden Excel table.

But level column is still empty in resulting Excel file.