### PR TITLE
Fix #345 Spaces in groupnames

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -7,5 +7,6 @@
     "arrowParens": "avoid",
     "trailingComma": "es5",
     "bracketSameLine": true,
-    "printWidth": 80
+    "printWidth": 80,
+    "endOfLine": "auto"
   }

--- a/src/app/component/circular-heatmap/circular-heatmap.component.css
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.css
@@ -8,8 +8,8 @@
   shape-rendering: crispEdges;
 }
 
-.normal-button {
-  background-color: white;
+.title-button {
+  background-color: transparent;
   border: none;
   text-align: left;
   cursor: pointer;

--- a/src/app/component/circular-heatmap/circular-heatmap.component.html
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.html
@@ -230,7 +230,9 @@
                 <mat-chip
                   #c="matChip"
                   *ngFor="let team of teamList"
-                  (click)="toggleTeamSelection(c)">
+                  (click)="toggleTeamSelection(c)"
+                  selected
+                  >
                   {{ team }}
                 </mat-chip>
               </mat-chip-list>

--- a/src/app/component/circular-heatmap/circular-heatmap.component.html
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.html
@@ -247,7 +247,7 @@
                 <mat-expansion-panel-header>
                   <mat-panel-title>
                     <button
-                      class="normal-button"
+                      class="title-button"
                       (click)="
                         $event.preventDefault();
                         navigate(

--- a/src/app/component/circular-heatmap/circular-heatmap.component.html
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.html
@@ -231,8 +231,7 @@
                   #c="matChip"
                   *ngFor="let team of teamList"
                   (click)="toggleTeamSelection(c)"
-                  selected
-                  >
+                  selected>
                   {{ team }}
                 </mat-chip>
               </mat-chip-list>

--- a/src/app/component/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.ts
@@ -75,11 +75,10 @@ export class CircularHeatmapComponent implements OnInit {
       .then(() => this.LoadTeamsFromMetaYaml())
       .then(() => this.LoadMaturityDataFromGeneratedYaml())
       .then(() => {
-          console.log(`${this.perfNow()}s: set filters: ${this.chips?.length}`);
-          this.matChipsArray = this.chips.toArray();
+        console.log(`${this.perfNow()}s: set filters: ${this.chips?.length}`);
+        this.matChipsArray = this.chips.toArray();
       });
   }
-
 
   @ViewChildren(MatChip) chips!: QueryList<MatChip>;
   matChipsArray: MatChip[] = [];

--- a/src/app/component/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.ts
@@ -68,12 +68,18 @@ export class CircularHeatmapComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    console.log(`${this.perfNow()}s: ngOnInit`);
     // Ensure that Levels and Teams load before MaturityData
     // using promises, since ngOnInit does not support async/await
     this.LoadMaturityLevels()
       .then(() => this.LoadTeamsFromMetaYaml())
-      .then(() => this.LoadMaturityDataFromGeneratedYaml());
+      .then(() => this.LoadMaturityDataFromGeneratedYaml())
+      .then(() => {
+          console.log(`${this.perfNow()}s: set filters: ${this.chips?.length}`);
+          this.matChipsArray = this.chips.toArray();
+      });
   }
+
 
   @ViewChildren(MatChip) chips!: QueryList<MatChip>;
   matChipsArray: MatChip[] = [];
@@ -255,7 +261,6 @@ export class CircularHeatmapComponent implements OnInit {
         this.teamList = this.YamlObject['teams'];
         this.teamGroups = this.YamlObject['teamGroups'];
         this.teamVisible = [...this.teamList];
-        console.log(`${this.perfNow()}s: LoadTeamsFromMetaYaml End`);
         resolve();
       });
     });
@@ -276,7 +281,6 @@ export class CircularHeatmapComponent implements OnInit {
           this.radial_labels.push('Level ' + y);
           this.maxLevelOfActivities = y;
         }
-        console.log(`${this.perfNow()}s: LoadMaturityLevels End`);
         resolve();
       });
     });
@@ -332,16 +336,6 @@ export class CircularHeatmapComponent implements OnInit {
     console.log('All chips', this.matChipsArray);
     // Update heatmap based on selection
     this.updateChips(prevSelectedChip);
-  }
-
-  ngAfterViewInit() {
-    // Putting all the chips inside an array
-
-    setTimeout(() => {
-      this.matChipsArray = this.chips.toArray();
-      this.updateChips(true);
-      this.reColorHeatmap();
-    }, 100);
   }
 
   updateChips(fromTeamGroup: any) {

--- a/src/app/component/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.ts
@@ -288,7 +288,7 @@ export class CircularHeatmapComponent implements OnInit {
 
   toggleTeamGroupSelection(chip: MatChip) {
     chip.toggleSelected();
-    let currChipValue = chip.value.replace(/\s/g, '');
+    let currChipValue = chip.value.trim();
 
     if (chip.selected) {
       this.selectedTeamChips = [currChipValue];
@@ -321,7 +321,7 @@ export class CircularHeatmapComponent implements OnInit {
 
   toggleTeamSelection(chip: MatChip) {
     chip.toggleSelected();
-    let currChipValue = chip.value.replace(/\s/g, '');
+    let currChipValue = chip.value.trim();
     let prevSelectedChip = this.selectedTeamChips;
     if (chip.selected) {
       this.teamVisible.push(currChipValue);
@@ -342,7 +342,7 @@ export class CircularHeatmapComponent implements OnInit {
     console.log('updating chips', fromTeamGroup);
     // Re select chips
     this.matChipsArray.forEach(chip => {
-      let currChipValue = chip.value.replace(/\s/g, '');
+      let currChipValue = chip.value.trim();
 
       if (this.teamVisible.includes(currChipValue)) {
         console.log(currChipValue);


### PR DESCRIPTION
Fixes #345 
* Space in team names, and team groups now work
* Removed unnecessary loop in toggleTeamGroupSelection()
* Fixed: Filter chips are now initialized after teams have been loaded (no longer just a 100ms delay)
* Fixed: Incorrect background color on hover over 
* Fixed: Team filter initializes with `selected` color (in sync with the 'All' group)