### PR TITLE
Remove sideeffect when opening modal dialog

### DIFF
--- a/src/app/component/circular-heatmap/circular-heatmap.component.html
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.html
@@ -251,7 +251,7 @@
                       class="title-button"
                       (click)="
                         $event.preventDefault();
-                        navigate(
+                        openActivityDetails(
                           currentDimension,
                           cardHeader,
                           activity['activityName']

--- a/src/app/component/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.ts
@@ -739,21 +739,21 @@ export class CircularHeatmapComponent implements OnInit {
     }
   }
 
-  navigate(dim: string, subdim: string, activityName: string) {
+  openActivityDetails(dim: string, subdim: string, activityName: string) {
     let navigationExtras = {
       dimension: dim,
       subDimension: subdim,
       activityName: activityName,
     };
-    this.yaml.setURI('./assets/YAML/generated/generated.yaml');
-    this.activityDetails = this.YamlObject[dim][subdim][activityName];
-    console.log(this.YamlObject);
-    console.log(this.YamlObject[dim][subdim]);
+    this.activityDetails = Object.assign(
+      {},
+      this.YamlObject[dim][subdim][activityName]
+    );
+
     if (this.activityDetails) {
       this.activityDetails.navigationExtras = navigationExtras;
     }
     console.log(this.activityDetails);
-    console.log(this.ALL_CARD_DATA);
     this.showOverlay = true;
   }
 


### PR DESCRIPTION
In Circular Heatmap, opening the modal dialog displaying the Activity Details, will affect `this.YamlObject`, and thus affect the export of `generated.yaml`, with an extra `navigationExtras` for all activities that have been opened. 

The fix was to assign a shallow copy of the activity, before adding the `navigationExtras`.