### PR TITLE
Allow team names to be controlled by meta.yaml

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,7 +7,7 @@ import { MappingComponent } from './component/mapping/mapping.component';
 import { MatrixComponent } from './component/matrix/matrix.component';
 import { ActivityDescriptionComponent } from './component/activity-description/activity-description.component';
 import { UsageComponent } from './component/usage/usage.component';
-import { Teams } from './component/teams/teams.component';
+import { TeamsComponent } from './component/teams/teams.component';
 
 const routes: Routes = [
   { path: '', component: MatrixComponent },
@@ -15,7 +15,7 @@ const routes: Routes = [
   { path: 'activity-description', component: ActivityDescriptionComponent },
   { path: 'mapping', component: MappingComponent },
   { path: 'usage', component: UsageComponent },
-  { path: 'teams', component: Teams },
+  { path: 'teams', component: TeamsComponent },
   { path: 'about', component: AboutUsComponent },
   { path: 'userday', component: UserdayComponent },
 ];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,7 +20,7 @@ import { UsageComponent } from './component/usage/usage.component';
 import { UserdayComponent } from './component/userday/userday.component';
 import { AboutUsComponent } from './component/about-us/about-us.component';
 import { DependencyGraphComponent } from './component/dependency-graph/dependency-graph.component';
-import { Teams } from './component/teams/teams.component';
+import { TeamsComponent } from './component/teams/teams.component';
 import { ToStringValuePipe } from './pipe/to-string-value.pipe';
 
 @NgModule({
@@ -37,7 +37,7 @@ import { ToStringValuePipe } from './pipe/to-string-value.pipe';
     UsageComponent,
     AboutUsComponent,
     DependencyGraphComponent,
-    Teams,
+    TeamsComponent,
     ToStringValuePipe,
     UserdayComponent,
   ],

--- a/src/app/component/activity-description/activity-description.component.ts
+++ b/src/app/component/activity-description/activity-description.component.ts
@@ -78,6 +78,7 @@ export class ActivityDescriptionComponent implements OnInit {
   YamlObject: any;
   GeneralLabels: string[] = [];
   KnowledgeLabels: string[] = [];
+  TeamList: string[] = [];
   rowIndex: number = 0;
   markdown: md = md();
   SAMMVersion: string = 'OWASP SAMM VERSION 2';
@@ -98,6 +99,9 @@ export class ActivityDescriptionComponent implements OnInit {
     console.log(this.perfNow() + 's: meta.yaml fetch');
     this.yaml.getJson().subscribe(data => {
       console.log(this.perfNow() + 's: meta.yaml');
+      this.GeneralLabels = data['strings']['en']['labels'];
+      this.KnowledgeLabels = data['strings']['en']['KnowledgeLabels'];
+      this.TeamList = data['teams']; // Genuine teams (the true source)
       console.log(this.perfNow() + 's: meta.yaml processed');
     });
     //gets value from generated folder

--- a/src/app/component/activity-description/activity-description.component.ts
+++ b/src/app/component/activity-description/activity-description.component.ts
@@ -95,16 +95,17 @@ export class ActivityDescriptionComponent implements OnInit {
     //gets value from sample file
     this.yaml.setURI('./assets/YAML/meta.yaml');
     // Function sets label data
+    console.log(this.perfNow() + 's: meta.yaml fetch');
     this.yaml.getJson().subscribe(data => {
-      this.YamlObject = data;
-      this.GeneralLabels = this.YamlObject['strings']['en']['labels'];
-      this.KnowledgeLabels =
-        this.YamlObject['strings']['en']['KnowledgeLabels'];
+      console.log(this.perfNow() + 's: meta.yaml');
+      console.log(this.perfNow() + 's: meta.yaml processed');
     });
     //gets value from generated folder
+    console.log(this.perfNow() + 's: generated.yaml fetch');
     this.yaml.setURI('./assets/YAML/generated/generated.yaml');
     // Function sets data
     this.yaml.getJson().subscribe(data => {
+      console.log(this.perfNow() + 's: generated.yaml downloaded');
       this.YamlObject = data;
 
       var allDimensionNames = Object.keys(this.YamlObject);
@@ -284,6 +285,7 @@ export class ActivityDescriptionComponent implements OnInit {
       );
       // console.log("data['teamsEvidence']", data['teamsEvidence']);
       this.openall();
+      console.log(this.perfNow() + 's: generated.yaml processed');
     });
   }
 
@@ -377,5 +379,9 @@ export class ActivityDescriptionComponent implements OnInit {
     this.accordion.forEach(element => {
       element.closeAll();
     });
+  }
+
+  perfNow() {
+    return (performance.now() / 1000).toFixed(3);
   }
 }

--- a/src/app/component/circular-heatmap/circular-heatmap.component.html
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.html
@@ -289,7 +289,7 @@
           class="normal-button"
           mat-raised-button
           class="downloadButtonClass"
-          (click)="SaveEditedYAMLfile()">
+          (click)="saveEditedYAMLfile()">
           Download edited YAML file
         </button>
         <button

--- a/src/app/component/circular-heatmap/circular-heatmap.component.html
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.html
@@ -263,13 +263,15 @@
                 </mat-expansion-panel-header>
                 <ng-template matExpansionPanelContent>
                   <ul class="team-list">
-                    <li
-                    *ngFor="let teamname of teamVisible">
+                    <li *ngFor="let teamname of teamVisible">
                       <mat-checkbox
-                      [checked]="activity.teamsImplemented[teamname]"
+                        [checked]="activity.teamsImplemented[teamname]"
                         color="primary"
-                      (click)="this.teamCheckbox(activityIndex, teamname); $event.preventDefault()">
-                      {{ teamname }}
+                        (click)="
+                          this.teamCheckbox(activityIndex, teamname);
+                          $event.preventDefault()
+                        ">
+                        {{ teamname }}
                       </mat-checkbox>
                     </li>
                   </ul>

--- a/src/app/component/circular-heatmap/circular-heatmap.component.html
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.html
@@ -218,7 +218,7 @@
                 </mat-chip>
                 <mat-chip
                   #c="matChip"
-                  *ngFor="let group of teamGroups | keyvalue"
+                  *ngFor="let group of teamGroups | keyvalue : unsorted"
                   (click)="toggleTeamGroupSelection(c)">
                   {{ group.key }}
                 </mat-chip>
@@ -264,13 +264,12 @@
                 <ng-template matExpansionPanelContent>
                   <ul class="team-list">
                     <li
-                      *ngFor="let item of activity.teamsImplemented | keyvalue">
+                    *ngFor="let teamname of teamVisible">
                       <mat-checkbox
-                        [checked]="item.value === true"
-                        *ngIf="teamVisible.includes(item.key | ToStringValue)"
+                      [checked]="activity.teamsImplemented[teamname]"
                         color="primary"
-                        (click)="this.teamCheckbox(activityIndex, item.key)">
-                        {{ item.key }}
+                      (click)="this.teamCheckbox(activityIndex, teamname); $event.preventDefault()">
+                      {{ teamname }}
                       </mat-checkbox>
                     </li>
                   </ul>

--- a/src/app/component/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.ts
@@ -41,7 +41,7 @@ type ProjectData = {
 })
 export class CircularHeatmapComponent implements OnInit {
   Routing: string = '/activity-description';
-  maxLevelOfActivities: number = -1;
+  maxLevelOfMaturity: number = -1;
   showActivityCard: boolean = false;
   cardHeader: string = '';
   cardSubheader: string = '';
@@ -95,7 +95,7 @@ export class CircularHeatmapComponent implements OnInit {
 
         // Initialize the card array
         let segmentTotalCount = this.segment_labels.length;
-        let cardTotalCount = segmentTotalCount * this.maxLevelOfActivities;
+        let cardTotalCount = segmentTotalCount * this.maxLevelOfMaturity;
         this.ALL_CARD_DATA = new Array(cardTotalCount).fill(null);
 
         // Process each card / sector
@@ -112,7 +112,7 @@ export class CircularHeatmapComponent implements OnInit {
 
             for (
               let level: number = 1;
-              level <= this.maxLevelOfActivities;
+              level <= this.maxLevelOfMaturity;
               level++
             ) {
               // Create and store each card (with activities for that level)
@@ -257,7 +257,7 @@ export class CircularHeatmapComponent implements OnInit {
         for (let x in this.YamlObject['strings']['en']['maturity_levels']) {
           var y = parseInt(x) + 1;
           this.radial_labels.push('Level ' + y);
-          this.maxLevelOfActivities = y;
+          this.maxLevelOfMaturity = y;
         }
         resolve();
       });
@@ -354,7 +354,7 @@ export class CircularHeatmapComponent implements OnInit {
         teamKey
       ];
 
-    this.saveState();
+    this.saveDataset();
     this.reColorHeatmap();
   }
 
@@ -449,7 +449,6 @@ export class CircularHeatmapComponent implements OnInit {
         _self.activityData = curr.Activity;
         _self.cardHeader = curr.SubDimension;
         _self.showActivityCard = true;
-        //console.log(_self.activityData)
       })
       .on('mouseover', function (d) {
         //console.log(d.toElement.__data__.Name)
@@ -797,14 +796,14 @@ export class CircularHeatmapComponent implements OnInit {
 
   ResetIsImplemented() {
     localStorage.removeItem('dataset');
-    this.loadState();
+    this.loadDataset();
   }
 
-  saveState() {
+  saveDataset() {
     localStorage.setItem('dataset', JSON.stringify(this.ALL_CARD_DATA));
   }
 
-  loadState() {
+  loadDataset() {
     var content = this.getDatasetFromBrowserStorage();
     if (content != null) {
       this.ALL_CARD_DATA = content;

--- a/src/app/component/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.ts
@@ -85,15 +85,10 @@ export class CircularHeatmapComponent implements OnInit {
 
   private LoadMaturityDataFromGeneratedYaml() {
     return new Promise<void>((resolve, reject) => {
-      console.log(
-        `${this.perfNow()}s: LoadMaturityDataFromGeneratedYaml Fetch`
-      );
+      console.log(`${this.perfNow()}s: LoadMaturityData Fetch`);
       this.yaml.setURI('./assets/YAML/generated/generated.yaml');
-
       this.yaml.getJson().subscribe(data => {
-        console.log(
-          `${this.perfNow()}s: LoadMaturityDataFromGeneratedYaml Downloaded`
-        );
+        console.log(`${this.perfNow()}s: LoadMaturityData Downloaded`);
         this.YamlObject = data;
         this.AddSegmentLabels(this.YamlObject);
         const localStorageData = this.getDatasetFromBrowserStorage();
@@ -144,9 +139,7 @@ export class CircularHeatmapComponent implements OnInit {
           this.segment_labels
         );
         this.noActivitytoGrey();
-        console.log(
-          `${this.perfNow()}s: LoadMaturityDataFromGeneratedYaml End`
-        );
+        console.log(`${this.perfNow()}s: LoadMaturityData End`);
         resolve();
       });
     });

--- a/src/app/component/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.ts
@@ -739,14 +739,36 @@ export class CircularHeatmapComponent implements OnInit {
     this.showOverlay = false;
   }
 
-  SaveEditedYAMLfile() {
+  saveEditedYAMLfile() {
+    this.setTeamsStatus(this.YamlObject, this.teamList, this.ALL_CARD_DATA);
     let yamlStr = yaml.dump(this.YamlObject);
+
     let file = new Blob([yamlStr], { type: 'text/csv;charset=utf-8' });
     var link = document.createElement('a');
     link.href = window.URL.createObjectURL(file);
     link.download = 'generated.yaml';
     link.click();
     link.remove();
+  }
+
+  setTeamsStatus(yamlObject: any, teamList: string[], card_data: cardSchema[]) {
+    // Loop through all activities from the card_data
+    for (let card of card_data) {
+      for (let activity of card.Activity) {
+        let dim: string = card.Dimension;
+        let subdim: string = card.SubDimension;
+        let activityName: string = activity.activityName;
+        let teamsImplemented: any = {};
+
+        // Get the state for all genuine teams of the activity
+        for (let team of teamList) {
+          teamsImplemented[team] = activity?.teamsImplemented[team] || false;
+        }
+        // Save the teams' state to the yaml object
+        yamlObject[dim][subdim][activityName].teamsImplemented =
+          teamsImplemented;
+      }
+    }
   }
 
   reColorHeatmap() {

--- a/src/app/component/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.ts
@@ -236,14 +236,10 @@ export class CircularHeatmapComponent implements OnInit {
     return undefined;
   }
 
-  private AddSegmentLabels(allDimensionNames: string[]) {
-    console.log(allDimensionNames);
-    for (var i = 0; i < allDimensionNames.length; i++) {
-      var allSubDimensionInThisDimension = Object.keys(
-        this.YamlObject[allDimensionNames[i]]
-      );
-      for (var j = 0; j < allSubDimensionInThisDimension.length; j++) {
-        this.segment_labels.push(allSubDimensionInThisDimension[j]);
+  private AddSegmentLabels(yampObject: any[]) {
+    for (let dim in yampObject) {
+      for (let subdim in yampObject[dim]) {
+        this.segment_labels.push(subdim);
       }
     }
     console.log(this.segment_labels);

--- a/src/app/component/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/component/circular-heatmap/circular-heatmap.component.ts
@@ -828,4 +828,8 @@ export class CircularHeatmapComponent implements OnInit {
   perfNow(): string {
     return (performance.now() / 1000).toFixed(3);
   }
+
+  unsorted() {
+    return 0;
+  }
 }

--- a/src/app/component/dependency-graph/dependency-graph.component.ts
+++ b/src/app/component/dependency-graph/dependency-graph.component.ts
@@ -61,21 +61,23 @@ export class DependencyGraphComponent implements OnInit {
     try {
       var activitysThatCurrenActivityIsDependentOn =
         this.YamlObject[activity]['dependsOn'];
-      for (
-        var j = 0;
-        j < activitysThatCurrenActivityIsDependentOn.length;
-        j++
-      ) {
-        this.checkIfNodeHasBeenGenerated(
-          activitysThatCurrenActivityIsDependentOn[j]
-        );
-        this.graphData['links'].push({
-          source: activitysThatCurrenActivityIsDependentOn[j],
-          target: activity,
-        });
-        this.populateGraphWithActivitiesCurrentActivityDependsOn(
-          activitysThatCurrenActivityIsDependentOn[j]
-        );
+      if (activitysThatCurrenActivityIsDependentOn) {
+        for (
+          var j = 0;
+          j < activitysThatCurrenActivityIsDependentOn.length;
+          j++
+        ) {
+          this.checkIfNodeHasBeenGenerated(
+            activitysThatCurrenActivityIsDependentOn[j]
+          );
+          this.graphData['links'].push({
+            source: activitysThatCurrenActivityIsDependentOn[j],
+            target: activity,
+          });
+          this.populateGraphWithActivitiesCurrentActivityDependsOn(
+            activitysThatCurrenActivityIsDependentOn[j]
+          );
+        }
       }
     } catch (e) {
       console.log(e);

--- a/src/app/component/matrix/matrix.component.html
+++ b/src/app/component/matrix/matrix.component.html
@@ -62,7 +62,9 @@
         <th mat-header-cell *matHeaderCellDef>{{ levels[i] }}</th>
         <td mat-cell *matCellDef="let element">
           <ul class="activity-list">
-            <li class="mat-cell-activity" *ngFor="let activity of element[lvl]; index as j">
+            <li
+              class="mat-cell-activity"
+              *ngFor="let activity of element[lvl]; index as j">
               <div>
                 <div>
                   <a

--- a/src/app/component/teams/teams.component.html
+++ b/src/app/component/teams/teams.component.html
@@ -6,7 +6,7 @@
     </ul>
   </div>
   <h2>Team Group</h2>
-  <div class="group-expand" *ngFor="let group of teamGroups | keyvalue">
+  <div class="group-expand" *ngFor="let group of teamGroups | keyvalue : unsorted">
     <h3>{{ group.key }}</h3>
     <div class="team-list">
       <ul>

--- a/src/app/component/teams/teams.component.spec.ts
+++ b/src/app/component/teams/teams.component.spec.ts
@@ -6,22 +6,22 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ymlService } from 'src/app/service/yaml-parser/yaml-parser.service';
 import { MatChip } from '@angular/material/chips';
 
-import { Teams } from './teams.component';
+import { TeamsComponent } from './teams.component';
 
-describe('Teams', () => {
-  let component: Teams;
-  let fixture: ComponentFixture<Teams>;
+describe('TeamsComponent', () => {
+  let component: TeamsComponent;
+  let fixture: ComponentFixture<TeamsComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       providers: [ymlService, HttpClientTestingModule],
       imports: [RouterTestingModule, HttpClientModule],
-      declarations: [Teams, MatChip],
+      declarations: [TeamsComponent, MatChip],
     }).compileComponents();
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(Teams);
+    fixture = TestBed.createComponent(TeamsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/component/teams/teams.component.ts
+++ b/src/app/component/teams/teams.component.ts
@@ -7,7 +7,7 @@ import * as yaml from 'js-yaml';
   templateUrl: './teams.component.html',
   styleUrls: ['./teams.component.css'],
 })
-export class Teams implements OnInit {
+export class TeamsComponent implements OnInit {
   YamlObject: any;
   teamList: any;
   teamGroups: Map<string, string[]> = new Map();

--- a/src/app/component/teams/teams.component.ts
+++ b/src/app/component/teams/teams.component.ts
@@ -27,7 +27,7 @@ export class TeamsComponent implements OnInit {
       console.log('teamGroups', this.teamGroups);
     });
   }
-  
+
   getTeamArray(key: string): string[] {
     return this.teamGroups.get(key) || [];
   }

--- a/src/app/component/teams/teams.component.ts
+++ b/src/app/component/teams/teams.component.ts
@@ -27,7 +27,12 @@ export class TeamsComponent implements OnInit {
       console.log('teamGroups', this.teamGroups);
     });
   }
+  
   getTeamArray(key: string): string[] {
     return this.teamGroups.get(key) || [];
+  }
+
+  unsorted() {
+    return 0;
   }
 }


### PR DESCRIPTION
Fixes #344. 

But the discussion in #344 is not quite complete, regarding how to find latest team status.

DSOMM should really centralize the load process of yaml and localstorage in a separate service.  But I'll leave that for later, @wurstbrot.