### PR TITLE
Fix mail.yaml error in downstream forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'devsecopsmaturitymodel/DevSecOps-MaturityModel'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The current `main.yaml` causes a daily build error in downstream forks (such as [vbakke/DevSecOps-MaturityModel](https://github.com/vbakke/DevSecOps-MaturityModel)).

Don't know if disabling the whole build step all together is the right solution, @wurstbrot. So, I'm happy for input  : )

* Log in to Docker Hub
    * Run docker/login-action@v2
        * with:
            * username: wurstbrot
            * ecr: auto
            * logout: true
    * Error: Username and password required