### PR TITLE
Minor link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ yarn build
 The definition of the activities are in the [data-repository](https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel-data). 
 
 ## Teams and Groups
-To customize these teams, you can create your own [meta.yaml](src/assets/meta.yaml)  file with your unique team definitions.
+To customize these teams, you can create your own [meta.yaml](src/assets/YAML/meta.yaml)  file with your unique team definitions.
 
 Assessments within the framework can be based on either a team or a specific application, which can be referred to as the context. Depending on how you define the context or teams, you may want to group them together.
 
@@ -129,7 +129,7 @@ Here are a couple of examples to illustrate this, in breakers the DSOMM word:
 - Multiple applications (teams) can belong to a single overarching team (application).
 - Multiple teams (teams) can belong to a larger department (group).
 
-Feel free to create your own [meta.yaml](src/assets/meta.yaml) file to tailor the framework to your specific needs and mount it in your environment (e.g. kubernetes or docker).
+Feel free to create your own [meta.yaml](src/assets/YAML/meta.yaml) file to tailor the framework to your specific needs and mount it in your environment (e.g. kubernetes or docker).
 Here is an example to start docker with customized meta.yaml:
 ```
 # Customized meta.yaml

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -17,7 +17,7 @@
     </button>
     <a
       class="github-fork-ribbon"
-      href="https://github.com/wurstbrot/DevSecOps-MaturityModel"
+      href="https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel"
       data-ribbon="Fork me on GitHub"
       title="Fork me on GitHub"
       >Fork me on GitHub</a

--- a/src/assets/Markdown Files/README.md
+++ b/src/assets/Markdown Files/README.md
@@ -98,7 +98,7 @@ docker run -d -p 80:8080 wurstbrot/dsomm:latest
 The definition of the activities are in the [data-repository](https://github.com/devsecopsmaturitymodel/DevSecOps-MaturityModel-data). 
 
 ## Teams and Groups
-To customize these teams, you can create your own [meta.yaml](src/assets/meta.yaml)  file with your unique team definitions.
+To customize these teams, you can create your own [meta.yaml](/assets/YAML/meta.yaml)  file with your unique team definitions.
 
 Assessments within the framework can be based on either a team or a specific application, which can be referred to as the context. Depending on how you define the context or teams, you may want to group them together.
 
@@ -106,7 +106,7 @@ Here are a couple of examples to illustrate this, in breakers the DSOMM word:
 - Multiple applications (teams) can belong to a single overarching team (application).
 - Multiple teams (teams) can belong to a larger department (group).
 
-Feel free to create your own [meta.yaml](src/assets/meta.yaml) file to tailor the framework to your specific needs and mount it in your environment (e.g. kubernetes or docker).
+Feel free to create your own [meta.yaml](/assets/YAML/meta.yaml) file to tailor the framework to your specific needs and mount it in your environment (e.g. kubernetes or docker).
 Here is an example to start docker with customized meta.yaml:
 ```
 # Customized meta.yaml


### PR DESCRIPTION
Noticed some minor errors for the meta.yaml links inside of DSOMM.
They were previously lining to a non exisisting file, e..g the meta.yaml links here: https://dsomm.owasp.org/usage/